### PR TITLE
Optimize CI to separate build and deploy

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -69,49 +69,6 @@ jobs:
         working-directory: website
         run: npm run lint
 
-  deploy:
-    name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
-    needs: ci
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Generate commit info
-        run: |
-          echo "{\"commit\": \"$(git rev-parse --short HEAD)\", \"date\": \"$(git show -s --format=%cI HEAD)\"}" > website/src/commit.json
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: v0.13.1
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build WASM
-        run: wasm-pack build --target web frontend_wasm -d ../website/frontend_wasm
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: website/package-lock.json
-
-      - name: Install website dependencies
-        working-directory: website
-        run: npm ci
-
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
@@ -124,10 +81,32 @@ jobs:
         working-directory: website
         run: npm run build
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: website-dist
+          path: website/dist
+          retention-days: 1
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: ci
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: website-dist
+          path: dist
+
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: website/dist
+          path: dist
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
- Build job now uploads the built website as an artifact
- Deploy job downloads the artifact instead of rebuilding
- Removes duplicate Rust, WASM, and Node.js setup from deploy job
- Significantly reduces deploy job runtime and resource usage