### PR TITLE
fix(website): format WikitextTemplate.tsx to satisfy Prettier check

### DIFF
--- a/website/src/views/components/wikipedia/templates/WikitextTemplate.tsx
+++ b/website/src/views/components/wikipedia/templates/WikitextTemplate.tsx
@@ -279,9 +279,7 @@ const canonicalHandlers = {
   "css-style": {
     render: (node: TemplateNode) => (
       <Wikitext
-        wikitext={
-          node.parameters[1]?.value ?? node.parameters[0]?.value ?? ""
-        }
+        wikitext={node.parameters[1]?.value ?? node.parameters[0]?.value ?? ""}
       />
     ),
     estimateLength: (node: TemplateNode) =>


### PR DESCRIPTION
The css-style handler's wikitext prop was hand-wrapped, failing the
`prettier --check` step in CI's lint. Collapse it back to a single line.

https://claude.ai/code/session_01VLafWkLg69uh4QBosobHdy